### PR TITLE
Add Cleaned VGIN dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Import accounts:
 | p-2104  |  jonahadkins_portsmouth_imports |
 | p-2105  |  jonahadkins_portsmouth_imports |
 | p-2106  | jonahadkins_portsmouth_imports  |
-| p-2109  |  probably will not do |
+| p-2109  |  DoctorSpeck_import |
 | p-2111  | jonahadkins_portsmouth_imports  |
 | p-2114  |  jonahadkins_portsmouth_imports |
 | p-2115  |  jonahadkins_portsmouth_imports |
@@ -43,7 +43,7 @@ Import accounts:
 | p-213002  | jonahadkins_portsmouth_imports  |
 | p-213101  | jonahadkins_portsmouth_imports  |
 | p-213103  |  jonahadkins_portsmouth_imports |
-| p-213104  | jonahadkins_portsmouth_imports  |
+| p-213104  | jonahadkins_portsmouth_imports; DoctorSpeck_import  |
 | p-2132  |  jonahadkins_portsmouth_imports  |
 | p-9801  |  jonahadkins_portsmouth_imports |
 
@@ -73,4 +73,3 @@ Import accounts:
 | shed  | 14,527 |
 | static_caravan  | 55 |
 | yes  | 3,311  |
-

--- a/data/VGIN-addresses-portsmouth-clean.osm
+++ b/data/VGIN-addresses-portsmouth-clean.osm
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:993a8113041f7f94bb779cc2eb8b0d1356290478bac7c7f241900964d6e9e9e6
+size 11603840


### PR DESCRIPTION
Updated Readme.md

Cleaned VGIN address dataset and converted to OSM file that can be used to resolve conflicts
* resolved road suffix errors
* cleaned dirty source data (unit number included in street field)